### PR TITLE
[feat] 增加chat readed功能;任務媒合成功可透過websocket通知

### DIFF
--- a/controller/tasksManageController.js
+++ b/controller/tasksManageController.js
@@ -8,6 +8,7 @@ const Task = require('../models/taskModel');
 const TaskTrans = require('../models/taskTransModel');
 const TaskValidator = require('../service/taskValidator');
 const statusMapping = require('../service/statusMapping');
+const { emitNotification } = require('../utils/websocket');
 
 const tasks = {
     getPostedTasksHist: handleErrorAsync(async (req, res, next) => {
@@ -674,6 +675,7 @@ const tasks = {
             } else {
                 return next(appError(500, '50001', `系統錯誤`));
             }
+            emitNotification(helpId, descriptionNew);
             return {
                 userId: helpId,
                 tag: '幫手通知',
@@ -690,6 +692,8 @@ const tasks = {
             taskId: taskId,
             createdAt: Date.now(),
         });
+        emitNotification(req.user._id, `您待媒合的任務：「${task.title} 」媒合成功，幫手可以進行任務囉！`);
+
         res.status(200).json(
             getHttpResponse({
                 message: '確認成功',

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -7,7 +7,7 @@ router.get('/list', function (req, res, next) {
     /**
      * #swagger.tags = ['Chat']
      * #swagger.summary = '取得聊天室列表 (Get all chatRoom list)'
-     * #swagger.description = '使用taskId作為聊天室的id'
+     * #swagger.description = '使用taskId作為聊天室的id。time表示最後一則訊息的時間。(無訊息時為null))'
      * #swagger.security=[{"Bearer": []}]
      */
 
@@ -28,13 +28,12 @@ router.get('/history', function (req, res, next) {
     /**
      * #swagger.tags = ['Chat']
      * #swagger.summary = '取得聊天室歷史訊息 (Get chat history by taskId)'
-     * #swagger.description = '每次查詢20筆最新訊息，使用lastChatId作為最後一筆訊息的id'
+     * #swagger.description = '查詢該聊天室的全部訊息'
      * #swagger.security=[{"Bearer": []}]
      */
 
     /**
      #swagger.parameters['taskId'] = {in: 'query',description: '使用taskId作為聊天d'}
-     #swagger.parameters['lastChatId'] = {in: 'query',description: '最後一筆聊天訊息的id'}
      #swagger.responses[200] = {
        description: '取得聊天室歷史訊息成功',
        schema: { $ref: '#/definitions/getChatHistory' }

--- a/swagger-defintion.js
+++ b/swagger-defintion.js
@@ -620,6 +620,7 @@ const getChatRoomList = {
             nickname: '滴妹',
             avatarPath: 'https://storage.googleapis.com/images/231432425.jpg',
         },
+        unreadCount: 0,
         time: '2021-09-27T07:00:00.000Z',
     },
     message: '取得聊天室列表成功',

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -3521,31 +3521,9 @@
     },
     "/chat/list": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
-        "summary": "取得聊天室列表 (Get all chatRoom list)",
-        "description": "使用taskId作為聊天室的id",
+        "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "取得聊天室列表成功",
-            "schema": {
-              "$ref": "#/definitions/getChatRoomList"
-            }
-          },
-          "500": {
-            "description": "系統錯誤",
-            "schema": {
-              "$ref": "#/definitions/Error500"
-            }
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
+        "responses": {}
       }
     },
     "/chat/history": {
@@ -3554,18 +3532,12 @@
           "Chat"
         ],
         "summary": "取得聊天室歷史訊息 (Get chat history by taskId)",
-        "description": "每次查詢20筆最新訊息，使用lastChatId作為最後一筆訊息的id",
+        "description": "查詢該聊天室的全部訊息",
         "parameters": [
           {
             "name": "taskId",
             "in": "query",
             "description": "使用taskId作為聊天d",
-            "type": "string"
-          },
-          {
-            "name": "lastChatId",
-            "in": "query",
-            "description": "最後一筆聊天訊息的id",
             "type": "string"
           }
         ],
@@ -5653,6 +5625,10 @@
                   "example": "https://storage.googleapis.com/images/231432425.jpg"
                 }
               }
+            },
+            "unreadCount": {
+              "type": "number",
+              "example": 0
             },
             "time": {
               "type": "string",

--- a/utils/userSockets.js
+++ b/utils/userSockets.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/utils/websocket.js
+++ b/utils/websocket.js
@@ -1,0 +1,12 @@
+const io = require('socket.io');
+const userSockets = require('./userSockets');
+
+function emitNotification(userId, message) {
+    if (userSockets[userId.toString()]) {
+        io.to(userSockets[userId.toString()]).emit('notification', message);
+    }
+}
+
+module.exports = {
+    emitNotification,
+};


### PR DESCRIPTION
- chat/history: 取消lastChatId query。查詢筆數從20改為全部
- chat/list: 增加unread，顯示有多少未讀訊息
- socket增加read監聽與發送，處理chat已讀狀態更新
- 新增utils/websocket.js: 如果在controller處理完資料，需要發即時訊息給用戶，可以透過該js處理
- tasksMaganeController.confirmHelper: 媒合成功後，發送即時訊息給相關用戶