### PR TITLE
[fix] 調整findTask邏輯

### DIFF
--- a/db/initTasks.js
+++ b/db/initTasks.js
@@ -37,6 +37,7 @@ const initTasks = async () => {
                 latitude: 25.0343073,
             },
             isUrgent: false,
+            currentHelperId: userCase2._id,
             helpers: [
                 {
                     helperId: userCase2._id,

--- a/swagger-defintion.js
+++ b/swagger-defintion.js
@@ -411,6 +411,7 @@ const getTaskDetails = {
         submittedInfo: {
             imgUrls: [],
         },
+        relation: 'poster',
     },
     message: '取得成功',
 };
@@ -656,29 +657,27 @@ const googleSignUp = {
     message: '第三方登入 google - 註冊',
 };
 
-const getPointsHistory =    {
+const getPointsHistory = {
     status: 'success',
-    data: [{
-        tag: "刊登任務",
-        taskId: "64869b36f50efe405623a154",
-        taskTitle: "需求短期家庭清潔工",
-        money: {
-        "salary": 350,
-        "exposurePlan": 50,
-        "platform": 0,
-        "superCoin": -350,
-        "helperCoin": -50
+    data: [
+        {
+            tag: '刊登任務',
+            taskId: '64869b36f50efe405623a154',
+            taskTitle: '需求短期家庭清潔工',
+            money: {
+                salary: 350,
+                exposurePlan: 50,
+                platform: 0,
+                superCoin: -350,
+                helperCoin: -50,
+            },
+            desc: ['預扣薪水', '黃金曝光'],
+            role: '案主',
+            createdAt: '2023-06-12T04:12:38.764Z',
         },
-        desc: [
-        "預扣薪水",
-        "黃金曝光"
-        ],
-        role: "案主",
-        createdAt: "2023-06-12T04:12:38.764Z"
-      }
     ],
     message: '取得成功',
-}
+};
 
 module.exports = {
     Success,

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -5303,6 +5303,10 @@
                   "items": {}
                 }
               }
+            },
+            "relation": {
+              "type": "string",
+              "example": "poster"
             }
           }
         },


### PR DESCRIPTION
- fix: 案主重新上架後，曾經申請過的幫手無法重新接案
- fix: 找任務的置頂區，需要filter任務方案是"黃金方案"
- modify: findTask/detail 增加relation欄位，可辨識該任務與自己的關係