### PR TITLE
FIX：任務的評價、幫手 bug 修復

### DIFF
--- a/controller/tasksManageController.js
+++ b/controller/tasksManageController.js
@@ -398,11 +398,7 @@ const tasks = {
                         path: 'reviews',
                         select: 'poster.star',
                     });
-                    console.log("------helperData------")
-                    console.log(helperData)
                     const categories = helperData.reduce((acc, task) => {
-                        console.log("------task.reviews-----")
-                        console.log(task.reviews)
                         const existingCategory = acc.find((category) => category.name === task.category);
                         if (existingCategory) {
                             existingCategory.star += task.reviews?.poster?.star || 0;
@@ -886,6 +882,7 @@ const tasks = {
                         status: 'completed',
                         'time.completedAt': Date.now(),
                         'time.updatedAt': Date.now(),
+                        reviews: reviewUpdate._id,
                     },
                 },
                 { new: true },

--- a/controller/tasksManageController.js
+++ b/controller/tasksManageController.js
@@ -383,7 +383,7 @@ const tasks = {
                 task.helpers.map(async (helper) => {
                     const completedTasks = await Task.countDocuments({
                         helpers: { $elemMatch: { helperId: helper.helperId._id, status: 'paired' } },
-                        status: 'completed',
+                        $or: [{ status: 'completed' }, { status: 'confirmed' }],
                     });
                     const numOfTasks = await Task.countDocuments({
                         helpers: { $elemMatch: { helperId: helper.helperId._id, status: 'paired' } },
@@ -1031,7 +1031,11 @@ const tasks = {
                 });
                 await Task.findByIdAndUpdate(task._id, { $set: { status: 'deleted',
                                                                  statusReason: '系統下架已過期任務',
-                                                                 'time.updatedAt': Date.now() }});
+                                                                 helpers: task.helpers.map((helper) => ({
+                                                                    helperId: helper.helperId,
+                                                                    status: 'dropped',
+                                                                })),
+                                                                'time.updatedAt': Date.now() }});
                 count++;
                 console.log(count)
             }

--- a/controller/tasksManageController.js
+++ b/controller/tasksManageController.js
@@ -169,6 +169,7 @@ const tasks = {
                     helpers: {
                         $elemMatch: {
                             helperId: userId,
+                            status: 'paired',
                         },
                     },
                 },


### PR DESCRIPTION
- 當完成評價的時候，在 tasks 寫入 reveiewId 
- 幫手撈出的任務資料，必須加上 paired
- 調整 completedTasks的定義：計算幫手評價(完成率)的時候，擴大計算 confirmed 的狀態
  (完成率=completedTasks/numOfTasks)
- 已過期的任務，踢掉所有幫手